### PR TITLE
Implement banner edit and filtering

### DIFF
--- a/src/main/java/org/example/bookmarket/banner/controller/BannerApiController.java
+++ b/src/main/java/org/example/bookmarket/banner/controller/BannerApiController.java
@@ -1,0 +1,23 @@
+package org.example.bookmarket.banner.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.bookmarket.banner.entity.Banner;
+import org.example.bookmarket.banner.service.BannerService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/banners")
+@RequiredArgsConstructor
+public class BannerApiController {
+    private final BannerService bannerService;
+
+    @GetMapping
+    public ResponseEntity<List<Banner>> banners() {
+        return ResponseEntity.ok(bannerService.getBanners());
+    }
+}

--- a/src/main/java/org/example/bookmarket/banner/controller/BannerPageController.java
+++ b/src/main/java/org/example/bookmarket/banner/controller/BannerPageController.java
@@ -2,6 +2,7 @@ package org.example.bookmarket.banner.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.example.bookmarket.banner.entity.Banner;
+import org.example.bookmarket.banner.entity.BannerStatus;
 import org.example.bookmarket.banner.service.BannerService;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -14,21 +15,36 @@ public class BannerPageController {
     private final BannerService bannerService;
 
     @GetMapping
-    public String list(Model model) {
-        model.addAttribute("banners", bannerService.getBanners());
+    public String list(@RequestParam(name = "all", defaultValue = "false") boolean all, Model model) {
+        model.addAttribute("banners", bannerService.getBanners(all));
         model.addAttribute("bannerForm", Banner.builder().build());
+        model.addAttribute("showAll", all);
+        return "banner/manager";
+    }
+
+    @GetMapping("/{id}")
+    public String edit(@PathVariable Long id, @RequestParam(name = "all", defaultValue = "false") boolean all, Model model) {
+        model.addAttribute("banners", bannerService.getBanners(all));
+        model.addAttribute("bannerForm", bannerService.getBanner(id));
+        model.addAttribute("showAll", all);
         return "banner/manager";
     }
 
     @PostMapping
-    public String create(@ModelAttribute Banner banner) {
+    public String create(@ModelAttribute Banner banner, @RequestParam(name = "all", defaultValue = "false") boolean all) {
         bannerService.saveBanner(banner);
-        return "redirect:/admin/banners";
+        return "redirect:/admin/banners" + (all ? "?all=true" : "");
     }
 
     @PostMapping("/{id}/delete")
-    public String delete(@PathVariable Long id) {
+    public String delete(@PathVariable Long id, @RequestParam(name = "all", defaultValue = "false") boolean all) {
         bannerService.deleteBanner(id);
-        return "redirect:/admin/banners";
+        return "redirect:/admin/banners" + (all ? "?all=true" : "");
+    }
+
+    @PostMapping("/{id}/toggle")
+    public String toggle(@PathVariable Long id, @RequestParam(name = "all", defaultValue = "false") boolean all) {
+        bannerService.toggleBannerStatus(id);
+        return "redirect:/admin/banners" + (all ? "?all=true" : "");
     }
 }

--- a/src/main/java/org/example/bookmarket/banner/entity/Banner.java
+++ b/src/main/java/org/example/bookmarket/banner/entity/Banner.java
@@ -4,6 +4,12 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.example.bookmarket.common.TimeEntity;
 
+import org.example.bookmarket.banner.entity.BannerStatus;
+
+/**
+ * Banner entity representing promotional banners.
+ */
+
 @Entity
 @Table(name = "banner")
 @Getter
@@ -18,11 +24,22 @@ public class Banner extends TimeEntity {
     private String title;
     private Integer sortOrder;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private BannerStatus status = BannerStatus.ACTIVE;
+
     @Builder
-    public Banner(String imageUrl, String link, String title, Integer sortOrder) {
+    public Banner(String imageUrl, String link, String title, Integer sortOrder, BannerStatus status) {
         this.imageUrl = imageUrl;
         this.link = link;
         this.title = title;
         this.sortOrder = sortOrder;
+        if (status != null) {
+            this.status = status;
+        }
+    }
+
+    public void changeStatus(BannerStatus status) {
+        this.status = status;
     }
 }

--- a/src/main/java/org/example/bookmarket/banner/entity/BannerStatus.java
+++ b/src/main/java/org/example/bookmarket/banner/entity/BannerStatus.java
@@ -1,0 +1,6 @@
+package org.example.bookmarket.banner.entity;
+
+public enum BannerStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/src/main/java/org/example/bookmarket/banner/repository/BannerRepository.java
+++ b/src/main/java/org/example/bookmarket/banner/repository/BannerRepository.java
@@ -1,10 +1,12 @@
 package org.example.bookmarket.banner.repository;
 
 import org.example.bookmarket.banner.entity.Banner;
+import org.example.bookmarket.banner.entity.BannerStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface BannerRepository extends JpaRepository<Banner, Long> {
+    List<Banner> findAllByStatusOrderBySortOrderAsc(BannerStatus status);
     List<Banner> findAllByOrderBySortOrderAsc();
 }

--- a/src/main/java/org/example/bookmarket/banner/service/BannerService.java
+++ b/src/main/java/org/example/bookmarket/banner/service/BannerService.java
@@ -2,6 +2,7 @@ package org.example.bookmarket.banner.service;
 
 import lombok.RequiredArgsConstructor;
 import org.example.bookmarket.banner.entity.Banner;
+import org.example.bookmarket.banner.entity.BannerStatus;
 import org.example.bookmarket.banner.repository.BannerRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,8 +15,16 @@ public class BannerService {
     private final BannerRepository bannerRepository;
 
     @Transactional(readOnly = true)
+    public List<Banner> getBanners(boolean all) {
+        if (all) {
+            return bannerRepository.findAllByOrderBySortOrderAsc();
+        }
+        return bannerRepository.findAllByStatusOrderBySortOrderAsc(BannerStatus.ACTIVE);
+    }
+
+    @Transactional(readOnly = true)
     public List<Banner> getBanners() {
-        return bannerRepository.findAllByOrderBySortOrderAsc();
+        return getBanners(false);
     }
 
     @Transactional
@@ -26,6 +35,16 @@ public class BannerService {
     @Transactional
     public void deleteBanner(Long id) {
         bannerRepository.deleteById(id);
+    }
+
+    @Transactional
+    public void toggleBannerStatus(Long id) {
+        Banner banner = getBanner(id);
+        if (banner.getStatus() == BannerStatus.ACTIVE) {
+            banner.changeStatus(BannerStatus.INACTIVE);
+        } else {
+            banner.changeStatus(BannerStatus.ACTIVE);
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,4 +1,4 @@
-INSERT INTO banner (image_url, link, title, sort_order, created_at, updated_at) VALUES
-                                                                                    ('https://images.unsplash.com/photo-1550399105-c4db5fb85c18?q=80&w=2071&auto=format&fit=crop', '/', 'AI가 돕는 합리적인 중고 책 거래, 북적북적!', 1, NOW(), NOW()),
-                                                                                    ('https://images.unsplash.com/photo-1524995997946-a1c2e315a42f?q=80&w=2071&auto=format&fit=crop', '/used-books/new', '책을 쉽고 빠르게 등록하세요!', 2, NOW(), NOW()),
-                                                                                    ('https://images.unsplash.com/photo-1513475382585-d06e58bcb0e6?q=80&w=2071&auto=format&fit=crop', '/promo', '북적북적 프로모션을 확인하세요!', 3, NOW(), NOW());
+INSERT INTO banner (image_url, link, title, sort_order, status, created_at, updated_at) VALUES
+    ('https://images.unsplash.com/photo-1550399105-c4db5fb85c18?q=80&w=2071&auto=format&fit=crop', '/', 'AI가 돕는 합리적인 중고 책 거래, 북적북적!', 1, 'ACTIVE', NOW(), NOW()),
+    ('https://images.unsplash.com/photo-1524995997946-a1c2e315a42f?q=80&w=2071&auto=format&fit=crop', '/used-books/new', '책을 쉽고 빠르게 등록하세요!', 2, 'ACTIVE', NOW(), NOW()),
+    ('https://images.unsplash.com/photo-1513475382585-d06e58bcb0e6?q=80&w=2071&auto=format&fit=crop', '/promo', '북적북적 프로모션을 확인하세요!', 3, 'ACTIVE', NOW(), NOW());

--- a/src/main/resources/templates/banner/manager.html
+++ b/src/main/resources/templates/banner/manager.html
@@ -10,7 +10,7 @@
   <div th:replace="~{fragments/header :: header}"></div>
   <main class="flex-1 p-6 max-w-3xl mx-auto w-full">
     <h1 class="text-xl font-bold mb-4">배너 관리</h1>
-    <form th:action="@{/admin/banners}" method="post" class="space-y-2 mb-6" th:object="${bannerForm}">
+    <form th:action="@{/admin/banners(all=${showAll})}" method="post" class="space-y-2 mb-6" th:object="${bannerForm}">
       <input type="hidden" th:field="*{id}" />
       <div>
         <label class="block text-sm">이미지 URL</label>
@@ -28,7 +28,21 @@
         <label class="block text-sm">정렬 순서</label>
         <input type="number" th:field="*{sortOrder}" class="border w-full" />
       </div>
+      <div>
+        <label class="block text-sm">상태</label>
+        <select th:field="*{status}" class="border w-full">
+          <option th:value="${T(org.example.bookmarket.banner.entity.BannerStatus).ACTIVE}">ACTIVE</option>
+          <option th:value="${T(org.example.bookmarket.banner.entity.BannerStatus).INACTIVE}">INACTIVE</option>
+        </select>
+      </div>
       <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">저장</button>
+    </form>
+
+    <form method="get" class="mb-4">
+      <label class="inline-flex items-center">
+        <input type="checkbox" name="all" value="true" th:checked="${showAll}" class="mr-2" onchange="this.form.submit()" />
+        비활성 포함
+      </label>
     </form>
 
     <table class="w-full text-left border">
@@ -38,6 +52,9 @@
         <th class="p-2">타이틀</th>
         <th class="p-2">링크</th>
         <th class="p-2">순서</th>
+        <th class="p-2">상태</th>
+        <th class="p-2">수정</th>
+        <th class="p-2">토글</th>
         <th class="p-2">삭제</th>
       </tr>
       </thead>
@@ -47,8 +64,17 @@
         <td class="p-2" th:text="${b.title}"></td>
         <td class="p-2" th:text="${b.link}"></td>
         <td class="p-2" th:text="${b.sortOrder}"></td>
+        <td class="p-2" th:text="${b.status}"></td>
         <td class="p-2">
-          <form th:action="@{/admin/banners/{id}/delete(id=${b.id})}" method="post">
+          <a th:href="@{/admin/banners/{id}(id=${b.id},all=${showAll})}" class="text-green-600">수정</a>
+        </td>
+        <td class="p-2">
+          <form th:action="@{/admin/banners/{id}/toggle(id=${b.id},all=${showAll})}" method="post">
+            <button type="submit" class="text-blue-600">토글</button>
+          </form>
+        </td>
+        <td class="p-2">
+          <form th:action="@{/admin/banners/{id}/delete(id=${b.id},all=${showAll})}" method="post">
             <button type="submit" class="text-red-600">삭제</button>
           </form>
         </td>

--- a/src/main/resources/templates/fragments/banner.html
+++ b/src/main/resources/templates/fragments/banner.html
@@ -3,25 +3,11 @@
 <section th:fragment="banner" class="relative min-h-[218px] rounded-lg overflow-hidden">
     <div class="swiper hero-swiper h-full">
         <div class="swiper-wrapper">
-            <a href="/" class="swiper-slide relative block">
-                <img class="absolute inset-0 w-full h-full object-cover" src="https://images.unsplash.com/photo-1550399105-c4db5fb85c18?q=80&w=2071&auto=format&fit=crop" />
+            <a th:each="b : ${banners}" th:href="${b.link}" class="swiper-slide relative block">
+                <img class="absolute inset-0 w-full h-full object-cover" th:src="${b.imageUrl}" />
                 <div class="absolute inset-0 bg-black/40"></div>
                 <div class="absolute inset-0 z-20 flex justify-center items-center p-4 text-center">
-                    <h1 class="text-white text-[28px] font-bold leading-tight">AI가 돕는 합리적인 중고 책 거래, 북적북적!</h1>
-                </div>
-            </a>
-            <a href="/used-books/new" class="swiper-slide relative block">
-                <img class="absolute inset-0 w-full h-full object-cover" src="https://images.unsplash.com/photo-1524995997946-a1c2e315a42f?q=80&w=2071&auto=format&fit=crop" />
-                <div class="absolute inset-0 bg-black/40"></div>
-                <div class="absolute inset-0 z-20 flex justify-center items-center p-4 text-center">
-                    <h1 class="text-white text-[28px] font-bold leading-tight">책을 쉽고 빠르게 등록하세요!</h1>
-                </div>
-            </a>
-            <a href="/promo" class="swiper-slide relative block">
-                <img class="absolute inset-0 w-full h-full object-cover" src="https://images.unsplash.com/photo-1513475382585-d06e58bcb0e6?q=80&w=2071&auto=format&fit=crop" />
-                <div class="absolute inset-0 bg-black/40"></div>
-                <div class="absolute inset-0 z-20 flex justify-center items-center p-4 text-center">
-                    <h1 class="text-white text-[28px] font-bold leading-tight">북적북적 프로모션을 확인하세요!</h1>
+                    <h1 class="text-white text-[28px] font-bold leading-tight" th:text="${b.title}"></h1>
                 </div>
             </a>
         </div>


### PR DESCRIPTION
## Summary
- support showing all banners or only active ones
- allow editing banners from manager page
- filter list via checkbox and preserve selection

## Testing
- `sh gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_686f6554387c83228b41299a2639f37c